### PR TITLE
Adjust canvas layout and controls

### DIFF
--- a/public/game.js
+++ b/public/game.js
@@ -4,20 +4,8 @@ import Proyectil from '../src/proyectil.js';
 const canvas = document.getElementById('gameCanvas');
 const ctx = canvas.getContext('2d');
 
-function resizeCanvas() {
-  canvas.width = window.innerWidth;
-  canvas.height = window.innerHeight;
-}
-
-resizeCanvas();
-
 // Instancia del jugador en la parte inferior
 const jugador = new Jugador(canvas.width / 2, canvas.height - 30);
-window.addEventListener('resize', () => {
-  resizeCanvas();
-  jugador.x = canvas.width / 2;
-  jugador.y = canvas.height - 30;
-});
 let direccion = 0; // -1 izquierda, 1 derecha
 
 // Crea un proyectil en x aleatoria y valor positivo
@@ -41,8 +29,9 @@ window.addEventListener('keyup', (e) => {
 
 // Controles táctiles: tocar lado izquierdo o derecho de la pantalla
 canvas.addEventListener('touchstart', (e) => {
-  const x = e.touches[0].clientX - canvas.getBoundingClientRect().left;
-  direccion = x < canvas.width / 2 ? -1 : 1;
+  const rect = canvas.getBoundingClientRect();
+  const x = e.touches[0].clientX - rect.left;
+  direccion = x < rect.width / 2 ? -1 : 1;
 });
 canvas.addEventListener('touchend', () => {
   direccion = 0;

--- a/public/style.css
+++ b/public/style.css
@@ -11,6 +11,10 @@ body {
 #gameCanvas {
   background: #eee;
   touch-action: none; /* Evita el doble tap en moviles */
+  width: 100vw;
+  height: 100vh;
+  max-width: 100vw;
+  max-height: 100vh;
 }
 
 #score {


### PR DESCRIPTION
## Summary
- revert responsive canvas sizing logic
- size canvas via CSS instead
- use CSS width for touch control midpoint

## Testing
- `node --check public/game.js`

------
https://chatgpt.com/codex/tasks/task_e_6852644b83c08331aa2817bf628534e1