### PR TITLE
Add life and timer mechanics

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,8 +10,11 @@
   <!-- Canvas principal donde se dibuja el juego -->
   <audio id="bgm" src="assets/happy.mp3" autoplay loop></audio>
   <canvas id="gameCanvas" width="800" height="600"></canvas>
-  <!-- Marcador de puntuación -->
+  <!-- HUD de juego -->
+  <div id="lives"></div>
+  <div id="timer"><img src="assets/reloj.png" /><span id="time">1:00</span></div>
   <div id="score">Puntuación: 0</div>
+  <div id="gameOver" class="hidden"></div>
   <script type="module" src="game.js"></script>
 </body>
 </html>

--- a/public/style.css
+++ b/public/style.css
@@ -25,3 +25,48 @@ body {
   font-family: sans-serif;
   font-size: 20px;
 }
+
+#lives {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+}
+
+#lives img {
+  width: 25px;
+  height: 25px;
+  margin-right: 2px;
+}
+
+#timer {
+  position: absolute;
+  top: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  color: #fff;
+  font-family: sans-serif;
+  font-size: 20px;
+  display: flex;
+  align-items: center;
+}
+
+#timer img {
+  width: 25px;
+  height: 25px;
+  margin-right: 5px;
+}
+
+#gameOver {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: #fff;
+  font-family: sans-serif;
+  font-size: 32px;
+  text-align: center;
+}
+
+.hidden {
+  display: none;
+}

--- a/src/proyectil.js
+++ b/src/proyectil.js
@@ -1,13 +1,21 @@
 // Clase que representa un proyectil que cae desde la parte superior
-// Imagen utilizada para representar al proyectil
-const imagenProyectil = new Image();
-imagenProyectil.src = 'assets/bananana.png';
+// Imágenes para los distintos tipos de proyectil
+const imagenes = {
+  corazon: new Image(),
+  calavera: new Image(),
+  reloj: new Image(),
+};
+imagenes.corazon.src = 'assets/cora.png';
+imagenes.calavera.src = 'assets/calaca.png';
+imagenes.reloj.src = 'assets/reloj.png';
 
 export default class Proyectil {
-  constructor(x, y, valor = 1) {
+  constructor(x, y, tipo = 'corazon', valor = 1) {
     this.x = x;
     this.y = y;
+    this.tipo = tipo;
     this.valor = valor;
+    this.imagen = imagenes[tipo] || imagenes.corazon;
     // Velocidad en pixeles por segundo. Antes eran 3 px por fotograma a 60fps
     this.velocidad = 180;
     this.tamano = 35;
@@ -20,7 +28,7 @@ export default class Proyectil {
 
   dibujar(ctx) {
     ctx.drawImage(
-      imagenProyectil,
+      this.imagen,
       this.x - this.tamano / 2,
       this.y - this.tamano / 2,
       this.tamano,


### PR DESCRIPTION
## Summary
- add projectile image selection for skull, heart and clock
- display hearts, timer and final score in HUD
- implement life and timer handling

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68533c6c906483319adfb370ee3e8cec