### PR TITLE
Add localization and retry function

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,7 @@ Este repositorio contiene dos versiones del proyecto navideño:
 El objetivo inicial es recrear la mecánica básica con un jugador que atrapa proyectiles. Más adelante se podrán añadir nuevas fases y personajes.
 
 Para ejecutar la demo solo abre `public/index.html` en tu navegador. También puede ser alojado en GitHub Pages configurando esa misma carpeta como fuente.
+
+## Novedades
+
+La versión actual incluye un sencillo sistema de localización con textos en alemán, español y japonés. Además se añadió un botón para reiniciar la partida sin recargar la página.

--- a/decisiones/20250629-localizacion-reintento.md
+++ b/decisiones/20250629-localizacion-reintento.md
@@ -1,0 +1,14 @@
+# Localizacion y reinicio
+
+## Resumen
+Se agrego soporte multilenguaje para HUD y un boton de reinicio. El idioma predeterminado es aleman.
+
+## Razonamiento
+La localizacion permite publicar el juego en distintas regiones sin modificar el codigo base. El boton de reinicio agiliza volver a jugar tras perder, mejorando la experiencia.
+
+## Alternativas consideradas
+- Cambiar manualmente el texto en HTML: descartado por poco escalable.
+- Recargar toda la pagina para reiniciar: evita logica extra pero interrumpe la musica.
+
+## Sugerencias
+La implementacion actual fija el idioma en el codigo. Futuras versiones podrian elegir idioma de forma dinamica.

--- a/public/game.js
+++ b/public/game.js
@@ -5,6 +5,14 @@ const canvas = document.getElementById('gameCanvas');
 const ctx = canvas.getContext('2d');
 const bgm = document.getElementById('bgm');
 
+const idioma = 'de';
+const textos = {
+  de: { score: 'Punkte', finalScore: 'Endpunktzahl', retry: 'Erneut versuchen' },
+  es: { score: 'Puntuación', finalScore: 'Puntuación final', retry: 'Reintentar' },
+  ja: { score: 'スコア', finalScore: '最終スコア', retry: '再挑戦' },
+};
+const t = textos[idioma];
+
 // Instancia del jugador en la parte inferior
 const jugador = new Jugador(canvas.width / 2, canvas.height - 30);
 // Ajusta la posicion vertical para mantener un margen de 20px
@@ -31,7 +39,7 @@ function formatearTiempo(t) {
 }
 
 function actualizarHud() {
-  document.getElementById('score').textContent = `Puntuación: ${jugador.puntuacion}`;
+  document.getElementById('score').textContent = `${t.score}: ${jugador.puntuacion}`;
   const contenedorVidas = document.getElementById('lives');
   contenedorVidas.innerHTML = '';
   for (let i = 0; i < vidas; i++) {
@@ -47,8 +55,11 @@ function finDelJuego() {
   direccion = 0;
   bgm.pause();
   const mensaje = document.getElementById('gameOver');
-  mensaje.textContent = `Puntuación final: ${jugador.puntuacion}`;
+  mensaje.textContent = `${t.finalScore}: ${jugador.puntuacion}`;
   mensaje.classList.remove('hidden');
+  const boton = document.getElementById('retryButton');
+  boton.textContent = t.retry;
+  boton.classList.remove('hidden');
 }
 
 // Control por teclado
@@ -70,6 +81,22 @@ canvas.addEventListener('touchstart', (e) => {
 canvas.addEventListener('touchend', () => {
   direccion = 0;
 });
+
+function reiniciarJuego() {
+  vidas = 3;
+  tiempoRestante = 60;
+  jugador.puntuacion = 0;
+  juegoTerminado = false;
+  document.getElementById('gameOver').classList.add('hidden');
+  const boton = document.getElementById('retryButton');
+  boton.classList.add('hidden');
+  bgm.currentTime = 0;
+  bgm.play();
+  proyectil = crearProyectil();
+  actualizarHud();
+  requestAnimationFrame(bucle);
+}
+document.getElementById('retryButton').addEventListener('click', reiniciarJuego);
 
 function bucle(timestamp) {
   const deltaTime = (timestamp - tiempoAnterior) / 1000 || 0;

--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="es">
+<html lang="de">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -13,8 +13,9 @@
   <!-- HUD de juego -->
   <div id="lives"></div>
   <div id="timer"><img src="assets/reloj.png" /><span id="time">1:00</span></div>
-  <div id="score">Puntuación: 0</div>
+  <div id="score"></div>
   <div id="gameOver" class="hidden"></div>
+  <button id="retryButton" class="hidden"></button>
   <script type="module" src="game.js"></script>
 </body>
 </html>

--- a/public/style.css
+++ b/public/style.css
@@ -70,3 +70,12 @@ body {
 .hidden {
   display: none;
 }
+
+#retryButton {
+  position: absolute;
+  top: calc(50% + 60px);
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 10px 20px;
+  font-size: 20px;
+}


### PR DESCRIPTION
## Summary
- localize HUD strings with default German text
- add retry button and restart logic
- style retry button
- document new features in README
- log decision about localization and restart

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68549b5f9a3483318d2975829999d8c0